### PR TITLE
 Include badge class object

### DIFF
--- a/apps/issuer/api.py
+++ b/apps/issuer/api.py
@@ -626,7 +626,7 @@ class IssuerBadgeInstanceList(AbstractIssuerAPIEndpoint):
             instances = current_issuer.badgeinstance_set.filter(revoked=False)
 
         serializer = BadgeInstanceSerializer(
-            instances, context={'request': request}, many=True
+            instances, context={'request': request, 'include_badge_class': True}, many=True
         )
 
         return Response(serializer.data)


### PR DESCRIPTION
With this change the data of the badge class is included within the assertion object. Previously I had to request the badge class objects in separate requests.

The BadgeInstanceSerializer uses a context parameter to check if the data of the badge class object should be included. I added the 'include_badge_class' parameter to the BadgeInstanceSerializer context in the api.py.

It seems to work fine, but should these context parameters be added in somewhere else, for example in the settings?
