### PR TITLE
Give revocation reason as query string

### DIFF
--- a/apps/issuer/api.py
+++ b/apps/issuer/api.py
@@ -676,7 +676,7 @@ class BadgeInstanceDetail(AbstractIssuerAPIEndpoint):
             - code: 404
               message: Assertion not found or user has inadequate permissions.
         """
-        if request.data.get('revocation_reason') is None:
+        if request.query_params.get('revocation_reason', None) is None:
             raise ValidationError("The parameter revocation_reason is required \
                                   to revoke a badge assertion")
         current_assertion = self.get_object(assertionSlug)
@@ -689,7 +689,7 @@ class BadgeInstanceDetail(AbstractIssuerAPIEndpoint):
 
         current_assertion.revoked = True
         current_assertion.revocation_reason = \
-            request.data.get('revocation_reason')
+            request.query_params.get('revocation_reason')
         current_assertion.image.delete()
         current_assertion.save()
 


### PR DESCRIPTION
Angular doesn't support sending request body data in DELETE methods. Assertion revocation is done with DELETE and it expects revocation_reason in request body. I had to change it so that it is given as query string instead to be able to use it from Angular.
